### PR TITLE
added tests workflow and bumped mlflow version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,14 @@ on:
     types: [ published ]
 
 jobs:
+  tests:
+    name: All checks are passed
+    uses: ./.github/workflows/tests.yaml
+    secrets: inherit
+  
   deploy:
     name: Build and push Docker image
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout commit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,5 +22,5 @@ jobs:
 
       - name: Test image
         run: |
-          make test IMAGE_TAG=development IMAGE_NAME=ghcr.io/neuro-inc/mlflow
+          make run-tests IMAGE_TAG=development IMAGE_NAME=ghcr.io/neuro-inc/mlflow
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    env:
+      local: true
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v3
+
+      - name: Build Docker Image
+        run: |
+          docker build -t "ghcr.io/neuro-inc/mlflow:development" .
+
+      - name: Test image
+        run: |
+          make test IMAGE_TAG=development IMAGE_NAME=ghcr.io/neuro-inc/mlflow
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: ["main"]
+  pull_request_target:
+    branches: ["main"]
 
 jobs:
   test:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
 
 jobs:
-  deploy:
+  test:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request_target:
     branches: ["main"]
+  workflow_call: {}
 
 jobs:
   test:

--- a/makefile
+++ b/makefile
@@ -1,0 +1,38 @@
+.PHONY: build
+
+IMAGE_NAME := mlflow-server
+IMAGE_TAG := latest
+
+venv:
+	python -m venv venv
+	. venv/bin/activate; \
+	pip install -U pip pip-tools
+
+.PHONY: test-requirements
+test-requirements: venv
+	. venv/bin/activate; \
+	python -m pip install mlflow pytest
+
+build:
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
+
+clean:
+	docker rmi $(IMAGE_NAME):$(IMAGE_TAG)
+
+.PHONY: run-server
+run-server:
+	@docker run --rm -it -p 8080:8080 --name mlflow-test-container -d $(IMAGE_NAME):$(IMAGE_TAG) \
+	server --host 0.0.0.0 --port 8080 --artifacts-destination /home --backend-store-uri sqlite:///mydb.sqlite
+
+.PHONY: stop-server
+stop-server:
+	docker stop mlflow-test-container
+
+.PHONY: test
+test: test-requirements
+	@rm -rf ./mlruns && \
+	. venv/bin/activate && \
+	pytest tests
+
+.PHONY: run-tests
+run-tests: run-server test stop-server

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ clean:
 
 .PHONY: run-server
 run-server:
-	@docker run --rm -it -p 8080:8080 --name mlflow-test-container -d $(IMAGE_NAME):$(IMAGE_TAG) \
+	docker run --rm -it -p 8080:8080 --name mlflow-test-container -d $(IMAGE_NAME):$(IMAGE_TAG) \
 	server --host 0.0.0.0 --port 8080 --artifacts-destination /home --backend-store-uri sqlite:///mydb.sqlite
 
 .PHONY: stop-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mlflow[extras,sqlserver,aliyun_oss]==2.1.1
+mlflow[extras,sqlserver,aliyun_oss]==2.19.0
 
 # MLFlow's dependencies, not listed in any requirements, neither in extras.
-psycopg2-binary==2.9.3
-pymysql==1.0.2
+psycopg2-binary==2.9.10
+pymysql==1.1.1
 mysqlclient==2.1.1

--- a/tests/test_mlflow_runs.py
+++ b/tests/test_mlflow_runs.py
@@ -1,0 +1,53 @@
+import mlflow.experiments
+import pytest
+import mlflow
+
+from mlflow import (
+    active_run,
+    end_run,
+    get_run,
+    start_run,
+)
+
+mlflow.set_tracking_uri("http://localhost:8080")
+
+
+def test_create_mlflow_run():
+    """Test creating a new MLflow run."""
+    with start_run() as run:
+        assert active_run() is not None
+        assert run.info.status == "RUNNING"
+        
+def test_end_mlflow_run():
+    """Test ending an MLflow run and verifying its status."""
+    run = start_run()
+    run_id = run.info.run_id
+    end_run()
+    ended_run = get_run(run_id)
+    assert ended_run.info.status == "FINISHED"
+
+def test_nested_runs():
+    """Test nested MLflow runs functionality."""
+    with start_run() as parent_run:
+        with start_run(nested=True) as child_run:
+            assert active_run() is not None
+            assert child_run.info.run_id != parent_run.info.run_id
+
+def test_log_params_and_metrics():
+    with start_run() as run:
+        mlflow.log_param("param1", "value1")
+        mlflow.log_metric("metric1", 1.0)
+        
+        run_id = run.info.run_id
+        fetched_run = get_run(run_id)
+        
+        assert fetched_run.data.params["param1"] == "value1"
+        assert fetched_run.data.metrics["metric1"] == 1.0
+
+def test_tags():
+    with start_run() as run:
+        mlflow.set_tag("tag1", "value1")
+        run_id = run.info.run_id
+        
+    fetched_run = get_run(run_id)
+    assert fetched_run.data.tags["tag1"] == "value1"


### PR DESCRIPTION
This pull request introduces a continuous integration (CI) workflow, updates the `makefile` with new targets for managing Docker images and running tests, and adds unit tests for MLflow runs. The most important changes include the addition of a CI workflow, enhancements to the `makefile`, and new tests for MLflow functionalities.

### CI Workflow Addition:
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R1-R24): Added a CI workflow to build and push Docker images, and run tests on pull requests to the main branch.

### Makefile Enhancements:
* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R1-R38): Added targets for building Docker images, running a server, stopping a server, and running tests.

### New Unit Tests for MLflow:
* [`tests/test_mlflow_runs.py`](diffhunk://#diff-3c27115dc07cc667e33022a406cf4161a426faafe1258a259dfdce30472e6670R1-R53): Added unit tests for creating, ending, and nesting MLflow runs, as well as logging parameters, metrics, and tags.