### PR TITLE
added login to ghcr to tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,14 +27,14 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker build -t "ghcr.io/neuro-inc/mlflow:${{ github.event.release.tag_name }}" .
+          docker build -t "ghcr.io/apolo-actions/mlflow:${{ github.event.release.tag_name }}" .
 
       - name: Tag Docker Image for platform-pipelines
         run: |
-          docker tag ghcr.io/neuro-inc/mlflow:${{ github.event.release.tag_name }} ghcr.io/neuro-inc/mlflow:pipelines
+          docker tag ghcr.io/apolo-actions/mlflow:${{ github.event.release.tag_name }} ghcr.io/apolo-actions/mlflow:pipelines
 
       - name: Push Docker Image
         run: |
-          docker push ghcr.io/neuro-inc/mlflow:${{ github.event.release.tag_name }}
-          docker push ghcr.io/neuro-inc/mlflow:pipelines
+          docker push ghcr.io/apolo-actions/mlflow:${{ github.event.release.tag_name }}
+          docker push ghcr.io/apolo-actions/mlflow:pipelines
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
   pull_request_target:
     branches: ["main"]
   workflow_call: {}
-
+  workflow_dispatch: {}
 jobs:
   test:
     name: Build and push Docker image
@@ -16,6 +16,13 @@ jobs:
     steps:
       - name: Checkout commit
         uses: actions/checkout@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCRIO_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,19 +28,19 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: docker/metadata-action@v4
         with:
-            images: ghcr.io/neuro-inc/mlflow
+            images: ghcr.io/apolo-actions/mlflow
             tags: |
               type=ref,event=pr
       - name: Build Docker Image
         run: |
-          docker build -t "ghcr.io/neuro-inc/mlflow:development" .
+          docker build -t "ghcr.io/apolo-actions/mlflow:development" .
 
       - name: Test image
         run: |
-          make run-tests IMAGE_TAG=development IMAGE_NAME=ghcr.io/neuro-inc/mlflow
+          make run-tests IMAGE_TAG=development IMAGE_NAME=ghcr.io/apolo-actions/mlflow
 
       - name: Push Docker Image
         run: |
-          docker tag ghcr.io/neuro-inc/mlflow:development ${{ steps.meta.outputs.tags }}
+          docker tag ghcr.io/apolo-actions/mlflow:development ${{ steps.meta.outputs.tags }}
           docker push ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,5 +41,6 @@ jobs:
 
       - name: Push Docker Image
         run: |
-          docker push ghcr.io/neuro-inc/mlflow:development ${{ steps.meta.outputs.tags }}
+          docker tag ghcr.io/neuro-inc/mlflow:development ${{ steps.meta.outputs.tags }}
+          docker push ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     env:
       local: true
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,14 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GHCRIO_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        if: github.event_name == 'pull_request'
+        uses: docker/metadata-action@v4
+        with:
+            images: ghcr.io/neuro-inc/mlflow
+            tags: |
+              type=ref,event=pr
       - name: Build Docker Image
         run: |
           docker build -t "ghcr.io/neuro-inc/mlflow:development" .
@@ -31,4 +38,8 @@ jobs:
       - name: Test image
         run: |
           make run-tests IMAGE_TAG=development IMAGE_NAME=ghcr.io/neuro-inc/mlflow
+
+      - name: Push Docker Image
+        run: |
+          docker push ghcr.io/neuro-inc/mlflow:development ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
This pull request includes updates to the Docker image handling in the CI and testing workflows. The most important changes involve updating the Docker image repository references and adding new steps to the testing workflow.

Changes to Docker image handling:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL30-R39): Updated the Docker image repository from `ghcr.io/neuro-inc/mlflow` to `ghcr.io/apolo-actions/mlflow` for building, tagging, and pushing Docker images.

Enhancements to testing workflow:

* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L9-R47): Added `workflow_dispatch` trigger and `permissions` for packages, included steps for logging into GHCR, extracting metadata for Docker, and pushing Docker images with metadata tags.