### PR TITLE
added packege permission to test job in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,8 @@ jobs:
   tests:
     name: All checks are passed
     uses: ./.github/workflows/tests.yaml
-    secrets: inherit
+    permissions:
+      packages: write
   
   deploy:
     name: Build and push Docker image

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: ["main"]
-  pull_request_target:
-    branches: ["main"]
   workflow_call: {}
   workflow_dispatch: {}
 jobs:
@@ -42,6 +40,7 @@ jobs:
           make run-tests IMAGE_TAG=development IMAGE_NAME=ghcr.io/apolo-actions/mlflow
 
       - name: Push Docker Image
+        if: github.event_name == 'pull_request'
         run: |
           docker tag ghcr.io/apolo-actions/mlflow:development ${{ steps.meta.outputs.tags }}
           docker push ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request includes a change to the `jobs` section in the `.github/workflows/ci.yaml` file to modify the permissions for the `tests` job.

Permissions modification:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL11-R12): Changed the `tests` job to include `permissions` with `packages: write` instead of inheriting secrets.