### PR TITLE
fixed release ci ghcr token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCRIO_USER }}
-          password: ${{ secrets.GHCRIO_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
     name: Build and push Docker image
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout commit
         uses: actions/checkout@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yaml` file. The change updates the Docker registry password to use the `GITHUB_TOKEN` secret instead of the `GHCRIO_TOKEN` secret.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL28-R28): Changed the `password` field to use `${{ secrets.GITHUB_TOKEN }}` instead of `${{ secrets.GHCRIO_TOKEN }}`.