### PR TITLE
Update mlflow image

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ inputs:
       Extra parameters for `mlflow server` command invocation.
 
 job:
-  image: ghcr.io/neuro-inc/mlflow:pipelines
+  image: ghcr.io/apolo-actions/mlflow:pipelines
   name: ${{ inputs.job_name }}
   preset: ${{ inputs.preset }}
   http_port: ${{ inputs.port }}


### PR DESCRIPTION
This pull request includes a change to the `action.yaml` file to update the Docker image used for the job.

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL67-R67): Changed the Docker image from `ghcr.io/neuro-inc/mlflow:pipelines` to `ghcr.io/apolo-actions/mlflow:pipelines`.